### PR TITLE
Add Jupyterlab Clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 - [AixViPMaP](https://github.com/AixViPMaP/jlab-theme) - AixViPMaP theme
 
 # Other
+- [Clipboard](https://github.com/Bamieh/jupyterlab-clipboard) - Paste images from clipboard
 - [lantern](https://github.com/timkpaine/lantern) - Data exploration kit
+
 
 # Resources
 


### PR DESCRIPTION
The clipboard extension allows you to paste images into your notebook. https://github.com/Bamieh/jupyterlab-clipboard

1. prompts user for path to save image as.
2. saves image on confirmation.
3. links image as markdown in the cell.