### PR TITLE
Fix broken Markdown Links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 - [lantern](https://github.com/timkpaine/lantern) - Data exploration kit
 - [ML Workspace](https://github.com/ml-tooling/ml-workspace) - All-in-one web IDE for machine learning and data science. Combines Jupyterlab, VS Code, Tensorflow, and many other tools/libraries into one Docker image.
 - [scriptedforms](https://github.com/SimonBiggs/scriptedforms) - Quickly create live-update GUIs for Python packages using Markdown and simple HTML elements.
-- [Variable inspector]:(https://github.com/lckr/jupyterlab-variableInspector) - Nice interactive variable inspector for your notebook
+- [Variable inspector](https://github.com/lckr/jupyterlab-variableInspector) - Nice interactive variable inspector for your notebook
 
 # Resources
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 
 
 # Editors
--[Spellchecker](https://github.com/ijmbarr/jupyterlab_spellchecker) - Spellchecker for markdown cells
+- [Spellchecker](https://github.com/ijmbarr/jupyterlab_spellchecker) - Spellchecker for markdown cells
 - [LaTeX](https://github.com/jupyterlab/jupyterlab-latex) - An extension for JupyterLab which allows for live-editing of LaTeX documents.
 - [DrawIO](https://github.com/QuantStack/jupyterlab-drawio) - An extension to draw diagrams in JupyterLab.
 - [Table of Contents](https://github.com/ian-r-rose/jupyterlab-toc) - Generates a table of content for your notebook and markdown documents.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 - [LaTeX](https://github.com/jupyterlab/jupyterlab-latex) - An extension for JupyterLab which allows for live-editing of LaTeX documents.
 - [DrawIO](https://github.com/QuantStack/jupyterlab-drawio) - An extension to draw diagrams in JupyterLab.
 - [Table of Contents](https://github.com/ian-r-rose/jupyterlab-toc) - Generates a table of content for your notebook and markdown documents.
-- [Collapsable Headings]:(https://github.com/aquirdTurtle/Collapsible_Headings) - Allows to collapse an entire group of cells under the same header
+- [Collapsable Headings](https://github.com/aquirdTurtle/Collapsible_Headings) - Allows to collapse an entire group of cells under the same header
 - [Go to definition](https://github.com/krassowski/jupyterlab-go-to-definition) - Allows you to <kbd>Alt</kbd> + <kbd>click</kbd> on a variable to jump to its definition.
 - [Code Formatter](https://github.com/ryantam626/jupyterlab_code_formatter) - Easily beautifies Python code inside JupyterLab using one of the formatters: Black/YAPF/AutoPEP8.
 - [LSP](https://github.com/krassowski/jupyterlab-lsp) - brings VS Code features (code navigation, hover suggestions, linters, autocompletion, etc.) to JupyterLab


### PR DESCRIPTION
Closes #20. 
Also added a space to render Spellchecker as part of Markdown list. 