### PR TITLE
Add jupyterlab-executor to the Other list

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 - [Variable inspector](https://github.com/lckr/jupyterlab-variableInspector) - Nice interactive variable inspector for your notebook
 - [Dask](https://github.com/dask/dask-labextension) - Manage Dask clusters, as well as embed Dask's dashboard plots directly into JupyterLab panes.
 - [jupyterlab-autoplay](https://github.com/remborg/autoplay) - Run and hide code cells automatically when opening a notebook.
+- [jupyterlab-executor](https://github.com/gavincyi/jupyterlab-executor) - A JupyterLab extension to execute the scripts from the file browser
 
 # Resources
 


### PR DESCRIPTION
The change add the extension `jupyterlab-executor` to the "Other" list