### PR TITLE
Add stickyland

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 
 
 # Editors
+- [StickyLand](https://github.com/xiaohk/stickyland) - Break the linear presentation of notebooks with sticky cells
 - [Spellchecker](https://github.com/jupyterlab-contrib/spellchecker) - Spellchecker for markdown cells
 - [LaTeX](https://github.com/jupyterlab/jupyterlab-latex) - An extension for JupyterLab which allows for live-editing of LaTeX documents.
 - [DrawIO](https://github.com/QuantStack/jupyterlab-drawio) - An extension to draw diagrams in JupyterLab.


### PR DESCRIPTION
This PR adds [stickyland](https://github.com/xiaohk/stickyland) under the `JupyterLab extension` section.

StickyLand is an extension that enables JupyterLab users to create sticky cells. Users can easily create sticky cells and freely arrange them with simple drag-and-drop. Users can also automatically execute these cells. With multiple sticky cells, users can even create a fully-fledged interactive dashboard.

![](https://i.imgur.com/KN51RQV.png)